### PR TITLE
ActiveRecord Dependency

### DIFF
--- a/lib/bulk/engine.rb
+++ b/lib/bulk/engine.rb
@@ -4,7 +4,7 @@ module Bulk
   class Engine < Rails::Engine
     initializer "do not include root in json" do
       # TODO: handle that nicely
-      ActiveRecord::Base.include_root_in_json = false
+      ActiveRecord::Base.include_root_in_json = false if defined? ActiveRecord
     end
 
     initializer "config paths" do |app|


### PR DESCRIPTION
This removes the ARecord dependency from the initializer.  I use MongoDB.
